### PR TITLE
DOC: mention option source(Boolean) in html_justification_tree//2

### DIFF
--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -58,7 +58,7 @@ user:file_search_path(css, library(scasp/web/css)).
 %
 %   Convert the tree to HTML. The  caller should use ovar_analyze_term/1
 %   on Tree to name variables and identify  singletons. This is not done
-%   in this predicate as the user may or  may not wish to combin the the
+%   in this predicate as the user may or  may not wish to combine the
 %   variable analysis with the bindings and/or model. Options processed:
 %
 %     - pred(Boolean)
@@ -66,6 +66,8 @@ user:file_search_path(css, library(scasp/web/css)).
 %     - justify_nmr(Boolean)
 %       When `false` (default `true`), do not omit a justification for
 %       the global constraints.
+%     - source(Boolean)
+%       When `false` (default `true`), do not omit source locations.
 
 :- det(html_justification_tree//2).
 


### PR DESCRIPTION
Add missing documentation for the `source(Boolean)` option of `html_justification_tree//2`.